### PR TITLE
Fix: Update redirects from skip.money to skip.build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,10 +6,10 @@
         { "source": "/connect/:path*", "destination": "https://skip-connect.mintlify-connect.com/connect/:path*" } 
     ],
     "redirects": [
-        { "source": "/slinky", "destination": "https://docs.skip.money/connect/overview", "statusCode": 301 },
-        { "source": "/skip-api", "destination": "https://docs.skip.money/go/general/getting-started", "statusCode": 301 },
-        { "source": "/skip-api/:path*", "destination": "https://docs.skip.money/go/:path*", "statusCode": 301 },
-        { "source": "/slinky/:path*", "destination": "https://docs.skip.money/connect/:path*", "statusCode": 301 },
+        { "source": "/slinky", "destination": "https://docs.skip.build/connect/overview", "statusCode": 301 },
+        { "source": "/skip-api", "destination": "https://docs.skip.build/go/general/getting-started", "statusCode": 301 },
+        { "source": "/skip-api/:path*", "destination": "https://docs.skip.build/go/:path*", "statusCode": 301 },
+        { "source": "/slinky/:path*", "destination": "https://docs.skip.build/connect/:path*", "statusCode": 301 },
         { "source": "/blocksdk(.*)", "destination": "https://github.com/skip-mev/block-sdk/blob/main/docs/0-integrate-the-sdk.md", "statusCode": 301 }
     ]
 }


### PR DESCRIPTION
## Summary
- Updated all redirect destinations from `docs.skip.money` to `docs.skip.build`
- Fixes broken redirects since skip.money domain is no longer working

## Changes
- Updated 4 redirect rules in `vercel.json`:
  - `/slinky` → `https://docs.skip.build/connect/overview`
  - `/skip-api` → `https://docs.skip.build/go/general/getting-started`
  - `/skip-api/:path*` → `https://docs.skip.build/go/:path*`
  - `/slinky/:path*` → `https://docs.skip.build/connect/:path*`

## Test plan
- [ ] Verify redirects work correctly after deployment
- [ ] Test `/skip-api` redirects to `https://docs.skip.build/go/general/getting-started`
- [ ] Test `/slinky` redirects to `https://docs.skip.build/connect/overview`

🤖 Generated with [Claude Code](https://claude.ai/code)